### PR TITLE
Improve dry-hit calculation and fix graph navigation

### DIFF
--- a/app/src/main/java/com/example/soilmonitor/MoistureFragment.kt
+++ b/app/src/main/java/com/example/soilmonitor/MoistureFragment.kt
@@ -135,17 +135,20 @@ class MoistureFragment : Fragment() {
                     plantIndex = idx,
                     hideNight   = true,
                     hideSep     = false,
-                    last24h     = false,
+                    viewMode    = SensorFragment.MODE_LAST_DIP,
                     bridge      = true,
                     showTrend   = true
                 )
                 parentFragmentManager.beginTransaction()
                     .replace(
-                        R.id.fragment_container,   // your activity’s fragment container
+                        R.id.fragment_container,
                         sensorFrag
                     )
                     .addToBackStack(null)
                     .commit()
+                activity?.findViewById<com.google.android.material.bottomnavigation.BottomNavigationView>(
+                    R.id.bottomNavigation
+                )?.menu?.findItem(R.id.nav_graph)?.isChecked = true
             }
         }
 
@@ -250,7 +253,14 @@ class MoistureFragment : Fragment() {
 
         /* 3) identical slope math as in SensorFragment */
         val values = entries.map { it.second.second }
-        val sIdx = values.indexOfLast { it <= wet }.let { if (it == -1) 0 else it }
+        val stableCount = 3
+        var sIdx = values.indexOfFirst { it <= wet }.let { if (it == -1) 0 else it }
+        for (i in 1 until values.size - stableCount) {
+            if (values[i - 1] > wet && (0 until stableCount).all { j -> values[i + j] <= wet }) {
+                sIdx = i
+                break
+            }
+        }
 
         val startX = entries[sIdx].first.toFloat()
         val startY = entries[sIdx].second.second

--- a/app/src/main/res/layout/fragment_sensor.xml
+++ b/app/src/main/res/layout/fragment_sensor.xml
@@ -47,13 +47,31 @@
         android:layout_marginTop="4dp"
         android:text="Hide day separators" />
 
-    <CheckBox
-        android:id="@+id/last24hCheckBox"
+    <RadioGroup
+        android:id="@+id/rangeRadioGroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:text="24 h only"
-        android:checked="true" />
+        android:orientation="horizontal"
+        android:layout_marginTop="4dp">
+
+        <RadioButton
+            android:id="@+id/range24hRadio"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="24 h" />
+
+        <RadioButton
+            android:id="@+id/rangeLastDipRadio"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="From last dip" />
+
+        <RadioButton
+            android:id="@+id/rangeAllRadio"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="All" />
+    </RadioGroup>
 
     <CheckBox
         android:id="@+id/bridgeGapsCheckBox"


### PR DESCRIPTION
## Summary
- refine moisture prediction algorithm in both fragments so it starts after a stable drop below the wet level
- mark the Graph item when navigating from Home without triggering another fragment

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68403c1d2cf4832dadbbc55d66013dc2